### PR TITLE
fix: flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Creates distributable packages for the current platform:
 | Linux | DEB, RPM, Flatpak, ZIP | x64 |
 | Windows | Squirrel Installer | x64 |
 
+#### Flatpak issues
+
+If you have issues building the flatpak try this first:
+
+```bash
+flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+```
+
+To get more output during the flatpak build:
+
+```bash
+DEBUG=electron-installer-flatpak,@malept/flatpak-bundler npm run make
+```
+
 ### Code Formatting
 
 ```bash

--- a/forge.config.js
+++ b/forge.config.js
@@ -47,6 +47,8 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-flatpak',
+      // debug this using:
+      //   DEBUG=electron-installer-flatpak,@malept/flatpak-bundler npm run make
       config: {
         options: {
           id: 'com.github.jsm174.vpxeditor',
@@ -61,6 +63,35 @@ module.exports = {
           })(),
           categories: ['Game', 'Utility'],
           genericName: 'Visual Pinball Table Editor',
+          runtime: "org.freedesktop.Platform",
+          runtimeVersion: "25.08",
+          sdk: "org.freedesktop.Sdk",
+          base: "org.electronjs.Electron2.BaseApp",
+          baseVersion: "25.08",
+          finishArgs: [
+            "--share=network",
+            "--share=ipc",
+            "--socket=x11",
+            "--socket=wayland",
+            "--socket=pulseaudio",
+            "--device=dri",
+            // "--talk-name=org.freedesktop.Notifications",
+            // "--talk-name=org.freedesktop.secrets",
+            "--filesystem=home"
+          ],
+          modules: [
+            {
+              // https://github.com/electron/forge/issues/2805
+              name: "zypak",
+              sources: [
+                {
+                  type: "git",
+                  url: "https://github.com/refi64/zypak",
+                  tag: "v2025.09",
+                },
+              ],
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
* forces zypak version as otherwise I can't build
* use modern runtime
* open x11 / wayland sockets
* enable DRI for OpenGL
* give access  to home dir

I get some various dbus warnings at runtime but does not seem to be breaking things
```
[3:1230/144929.215636:ERROR:dbus/bus.cc:408] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```
Logged dbus output as explained below looks ok
https://docs.flatpak.org/en/latest/sandbox-permissions.html#d-bus-access

Related bug #3 
Related icon issue #5 

How to test
```
DEBUG=electron-installer-flatpak,@malept/flatpak-bundler npm run make
flatpak install ./out/make/flatpak/x86_64/com.github.jsm174.vpxeditor_0.5.0-0-dev_x86_64.flatpak
flatpak run com.github.jsm174.vpxeditor
```