### PR TITLE
deps: upgrade to support vpin-wasm 0.20.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "vpx-editor",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vpx-editor",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@francisdb/vpin-wasm": "^0.20.11",
+        "@francisdb/vpin-wasm": "^0.20.12",
         "electron-squirrel-startup": "^1.0.1",
         "fs-extra": "^11.3.3",
         "monaco-editor": "^0.55.1",
@@ -1145,9 +1145,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
       "cpu": [
         "ppc64"
       ],
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -1213,9 +1213,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -1230,9 +1230,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -1247,9 +1247,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -1298,9 +1298,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -1315,9 +1315,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -1383,9 +1383,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1400,9 +1400,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -1417,9 +1417,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -1434,9 +1434,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
       "cpu": [
         "arm64"
       ],
@@ -1451,9 +1451,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -1468,9 +1468,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
       "cpu": [
         "arm64"
       ],
@@ -1485,9 +1485,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -1502,9 +1502,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
       "cpu": [
         "arm64"
       ],
@@ -1519,9 +1519,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -1536,9 +1536,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -1553,9 +1553,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -1570,9 +1570,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@francisdb/vpin-wasm": {
-      "version": "0.20.11",
-      "resolved": "https://registry.npmjs.org/@francisdb/vpin-wasm/-/vpin-wasm-0.20.11.tgz",
-      "integrity": "sha512-7s8bSse+3wKzuOeVp9K+KLgehs0KZjh4qcukixoG44Cbqsg/uLGmHR1E5v9j8UMdy+1CeFjziPh/n5hn79qhdg==",
+      "version": "0.20.12",
+      "resolved": "https://registry.npmjs.org/@francisdb/vpin-wasm/-/vpin-wasm-0.20.12.tgz",
+      "integrity": "sha512-I2ZtbhjZCwt5F/d9cMyQj4r6INbYcULXnpW3pfgqeBA9xxHVBc7LgKJfmcMj2yyDeK4eCF+U+U8k+A9WHbNsMQ==",
       "license": "MIT"
     },
     "node_modules/@gar/promisify": {
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
-      "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+      "version": "22.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
+      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
+      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3811,9 +3811,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001767",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
-      "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
       "dev": true,
       "funding": [
         {
@@ -4859,9 +4859,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "22.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
-      "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+      "version": "22.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
+      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5024,9 +5024,9 @@
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5037,32 +5037,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -8146,9 +8146,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vpx-editor",
   "productName": "VPX Editor",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Visual Pinball X Table Editor",
   "main": ".vite/build/main.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "vite": "^7.3.0"
   },
   "dependencies": {
-    "@francisdb/vpin-wasm": "^0.20.11",
+    "@francisdb/vpin-wasm": "^0.20.12",
     "electron-squirrel-startup": "^1.0.1",
     "fs-extra": "^11.3.3",
     "monaco-editor": "^0.55.1",

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -1981,7 +1981,7 @@ function parseMtlFile(content: string) {
     if (parts[0] === 'newmtl' && parts[1]) {
       material = {
         name: parts[1],
-        type_: 'Basic',
+        type: 'Basic',
         base_color: '#808080',
         glossy_color: '#000000',
         clearcoat_color: '#000000',

--- a/src/editor/texture-loader.ts
+++ b/src/editor/texture-loader.ts
@@ -17,7 +17,7 @@ interface VPXMaterial {
   opacity_active?: boolean;
   opacity_active_edge_alpha?: number;
   opacity?: number;
-  type_?: string;
+  type?: string;
   is_metal?: boolean;
 }
 
@@ -223,7 +223,7 @@ export function createMaterialFromVPX(
       matOptions.opacity = vpxMaterial.opacity;
     }
 
-    const isMetal = vpxMaterial.is_metal || vpxMaterial.type_?.toLowerCase() === 'metal';
+    const isMetal = vpxMaterial.is_metal || vpxMaterial.type?.toLowerCase() === 'metal';
     if (isMetal) {
       matOptions.metalness = 0.8;
     } else {

--- a/src/features/material-manager/desktop/editor-window.ts
+++ b/src/features/material-manager/desktop/editor-window.ts
@@ -22,7 +22,7 @@ window.vpxEditor.onInitMaterialEditor?.((data: MaterialEditorData) => {
   document.title = mode === 'new' ? 'New Material' : 'Clone Material';
 
   (document.getElementById('edit-name') as HTMLInputElement).value = (mat.name as string) || '';
-  (document.getElementById('edit-type') as HTMLSelectElement).value = (mat.type_ as string) || 'basic';
+  (document.getElementById('edit-type') as HTMLSelectElement).value = (mat.type as string) || 'basic';
   (document.getElementById('edit-elasticity') as HTMLInputElement).value = ((mat.elasticity as number) ?? 0).toFixed(3);
   (document.getElementById('edit-elasticity-falloff') as HTMLInputElement).value = (
     (mat.elasticity_falloff as number) ?? 0
@@ -77,7 +77,7 @@ function validateName(): boolean {
 
   const result = {
     name: (document.getElementById('edit-name') as HTMLInputElement).value.trim(),
-    type_: (document.getElementById('edit-type') as HTMLSelectElement).value,
+    type: (document.getElementById('edit-type') as HTMLSelectElement).value,
     elasticity: parseFloat((document.getElementById('edit-elasticity') as HTMLInputElement).value),
     elasticity_falloff: parseFloat((document.getElementById('edit-elasticity-falloff') as HTMLInputElement).value),
     friction: parseFloat((document.getElementById('edit-friction') as HTMLInputElement).value),

--- a/src/features/material-manager/shared/component.ts
+++ b/src/features/material-manager/shared/component.ts
@@ -175,7 +175,7 @@ export function initMaterialManagerComponent(
       const usage = findMaterialUsage(name);
       return {
         name,
-        type: (mat as unknown as Record<string, unknown>).type_ || 'basic',
+        type: (mat as unknown as Record<string, unknown>).type || 'basic',
         baseColor: colorToHexString(
           (mat as unknown as Record<string, unknown>).base_color as number | string | undefined
         ),
@@ -279,9 +279,9 @@ export function initMaterialManagerComponent(
         </div>
         <div class="prop-row">
           <label class="prop-label">Type</label>
-          <select class="prop-select" data-prop="type_">
-            <option value="basic" ${mat.type_ === 'basic' ? 'selected' : ''}>Basic</option>
-            <option value="metal" ${mat.type_ === 'metal' ? 'selected' : ''}>Metal</option>
+          <select class="prop-select" data-prop="type">
+            <option value="basic" ${mat.type === 'basic' ? 'selected' : ''}>Basic</option>
+            <option value="metal" ${mat.type === 'metal' ? 'selected' : ''}>Metal</option>
           </select>
         </div>
       </div>
@@ -417,7 +417,7 @@ export function initMaterialManagerComponent(
   function getDefaultMaterial(): Record<string, unknown> {
     return {
       name: 'NewMaterial',
-      type_: 'basic',
+      type: 'basic',
       wrap_lighting: 0.25,
       roughness: 0.5,
       glossy_image_lerp: 0.5,
@@ -456,8 +456,8 @@ export function initMaterialManagerComponent(
           <div class="prop-row">
             <label class="prop-label">Type</label>
             <select class="prop-select" id="edit-type">
-              <option value="basic" ${mat.type_ === 'basic' ? 'selected' : ''}>Basic</option>
-              <option value="metal" ${mat.type_ === 'metal' ? 'selected' : ''}>Metal</option>
+              <option value="basic" ${mat.type === 'basic' ? 'selected' : ''}>Basic</option>
+              <option value="metal" ${mat.type === 'metal' ? 'selected' : ''}>Metal</option>
             </select>
           </div>
         </div>
@@ -534,7 +534,7 @@ export function initMaterialManagerComponent(
         const result = {
           ...mat,
           name: (document.getElementById('edit-name') as HTMLInputElement).value.trim(),
-          type_: (document.getElementById('edit-type') as HTMLSelectElement).value,
+          type: (document.getElementById('edit-type') as HTMLSelectElement).value,
           elasticity: parseFloat((document.getElementById('edit-elasticity') as HTMLInputElement).value),
           elasticity_falloff: parseFloat(
             (document.getElementById('edit-elasticity-falloff') as HTMLInputElement).value

--- a/src/features/render-probe-manager/shared/component.ts
+++ b/src/features/render-probe-manager/shared/component.ts
@@ -1,6 +1,6 @@
 export interface RenderProbe {
   name: string;
-  type_: 'plane_reflection' | 'screen_space_transparency';
+  type: 'plane_reflection' | 'screen_space_transparency';
   roughness: number;
   reflection_plane?: { x: number; y: number; z: number; w: number };
   reflection_mode?: string;
@@ -77,7 +77,7 @@ export function initRenderProbeManagerComponent(
 
   function getDefaultProbe(): RenderProbe {
     return {
-      type_: 'plane_reflection',
+      type: 'plane_reflection',
       name: 'New Render Probe',
       roughness: 0,
       reflection_plane: { x: 0, y: 0, z: 1, w: 0 },
@@ -138,7 +138,7 @@ export function initRenderProbeManagerComponent(
     elements.propertiesContainer.style.display = 'block';
 
     const isProtected = isPlayfieldProbe(probe.name);
-    const isPlaneReflection = probe.type_ === 'plane_reflection';
+    const isPlaneReflection = probe.type === 'plane_reflection';
 
     elements.typePlane.checked = isPlaneReflection;
     elements.typeScreen.checked = !isPlaneReflection;
@@ -175,12 +175,12 @@ export function initRenderProbeManagerComponent(
     const isProtected = isPlayfieldProbe(probe.name);
 
     if (!isProtected) {
-      probe.type_ = elements.typePlane.checked ? 'plane_reflection' : 'screen_space_transparency';
+      probe.type = elements.typePlane.checked ? 'plane_reflection' : 'screen_space_transparency';
     }
 
     probe.roughness = parseInt(elements.roughness.value, 10);
 
-    if (probe.type_ === 'plane_reflection' && !isProtected) {
+    if (probe.type === 'plane_reflection' && !isProtected) {
       probe.reflection_plane = {
         x: parseFloat(elements.planeX.value) || 0,
         y: parseFloat(elements.planeY.value) || 0,
@@ -189,7 +189,7 @@ export function initRenderProbeManagerComponent(
       };
     }
 
-    if (probe.type_ === 'plane_reflection') {
+    if (probe.type === 'plane_reflection') {
       probe.reflection_mode = elements.reflectionMode.value;
       probe.disable_light_reflection = elements.disableLightmaps.checked;
     }

--- a/src/shared/table-upgrades.ts
+++ b/src/shared/table-upgrades.ts
@@ -26,7 +26,7 @@ interface OldPhysics {
 
 interface NewMaterial {
   name: string;
-  type_: string;
+  type: string;
   base_color: string;
   glossy_color: string;
   clearcoat_color: string;
@@ -82,7 +82,7 @@ function convertOldToNewMaterials(oldMaterials: OldMaterial[], oldPhysics: OldPh
 
     return {
       name: oldMat.name,
-      type_: oldMat.is_metal ? 'Metal' : 'Basic',
+      type: oldMat.is_metal ? 'Metal' : 'Basic',
       base_color: oldMat.base_color,
       glossy_color: oldMat.glossy_color,
       clearcoat_color: oldMat.clearcoat_color,
@@ -380,12 +380,67 @@ export async function cleanupCollectionItems(
   return modified;
 }
 
+export async function upgradeTypeFieldRename(
+  fs: FileSystemAdapter,
+  dir: string,
+  sendConsoleOutput?: ConsoleOutputCallback
+): Promise<boolean> {
+  let upgraded = false;
+
+  const materialsPath = joinPath(dir, 'materials.json');
+  if (await fs.exists(materialsPath)) {
+    try {
+      const materials = JSON.parse(await fs.readFile(materialsPath)) as Record<string, unknown>[];
+      let modified = false;
+      for (const mat of materials) {
+        if ('type_' in mat && !('type' in mat)) {
+          mat.type = mat.type_;
+          delete mat.type_;
+          modified = true;
+        }
+      }
+      if (modified) {
+        await fs.writeFile(materialsPath, JSON.stringify(materials, null, 2));
+        upgraded = true;
+        sendConsoleOutput?.('info', 'Upgraded materials.json: renamed type_ to type');
+      }
+    } catch (err) {
+      sendConsoleOutput?.('error', `Failed to upgrade materials type field: ${(err as Error).message}`);
+    }
+  }
+
+  const renderprobesPath = joinPath(dir, 'renderprobes.json');
+  if (await fs.exists(renderprobesPath)) {
+    try {
+      const probes = JSON.parse(await fs.readFile(renderprobesPath)) as Record<string, unknown>[];
+      let modified = false;
+      for (const probe of probes) {
+        if ('type_' in probe && !('type' in probe)) {
+          probe.type = probe.type_;
+          delete probe.type_;
+          modified = true;
+        }
+      }
+      if (modified) {
+        await fs.writeFile(renderprobesPath, JSON.stringify(probes, null, 2));
+        upgraded = true;
+        sendConsoleOutput?.('info', 'Upgraded renderprobes.json: renamed type_ to type');
+      }
+    } catch (err) {
+      sendConsoleOutput?.('error', `Failed to upgrade renderprobes type field: ${(err as Error).message}`);
+    }
+  }
+
+  return upgraded;
+}
+
 export async function runAllUpgrades(
   fs: FileSystemAdapter,
   dir: string,
   sendConsoleOutput?: ConsoleOutputCallback
 ): Promise<void> {
   await upgradeOldMaterialsFormat(fs, dir);
+  await upgradeTypeFieldRename(fs, dir, sendConsoleOutput);
   await upgradePlayfieldMeshVisibility(fs, dir, sendConsoleOutput);
   await upgradeLayersToPartGroups(fs, dir, sendConsoleOutput);
   await upgradePartGroupIsLocked(fs, dir, sendConsoleOutput);


### PR DESCRIPTION
- breaking change of switching `_type` to `type`.
- added support for upgrading work folders to that contain `_type` to `type`. 