### PR TITLE
misc: add support for flasher EXT_RENDER. bump vpin-wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "vpx-editor",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vpx-editor",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@francisdb/vpin-wasm": "^0.23.1",
+        "@francisdb/vpin-wasm": "^0.23.5",
         "electron-squirrel-startup": "^1.0.1",
         "fs-extra": "^11.3.3",
         "monaco-editor": "^0.55.1",
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@francisdb/vpin-wasm": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@francisdb/vpin-wasm/-/vpin-wasm-0.23.2.tgz",
-      "integrity": "sha512-+9m9RmhQHIeIP3bm3M3R9yWC+uhoUzUfD15MJEUF4XfG0C4i9xKxZLMD8SBqgEP/hWs9vbei29257be9Gvx3fA==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@francisdb/vpin-wasm/-/vpin-wasm-0.23.5.tgz",
+      "integrity": "sha512-+p3kQqGJPenQVoy6gs8qM00cR/r8TIVUEIyXDW6RLVChq5c42XHXk+z6Ydw654qgo8zmSMzpybNWsT63EM/oMA==",
       "license": "MIT"
     },
     "node_modules/@gar/promisify": {
@@ -2576,6 +2576,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2590,6 +2593,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2604,6 +2610,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,6 +2627,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2632,6 +2644,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2646,6 +2661,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2660,6 +2678,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2674,6 +2695,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,6 +2712,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,6 +2729,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2716,6 +2746,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2730,6 +2763,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2744,6 +2780,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3523,9 +3562,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
-      "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
+      "integrity": "sha512-OZd0e2mU11ClX8+IdXe3r0dbqMEznRiT4TfbhYIbcRPZkqJ7Qwer8ij3GZAmLsRKa+II9V1v5czCkvmHH3XZBg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3808,9 +3847,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001778",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
-      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
+      "version": "1.0.30001780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
+      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
       "dev": true,
       "funding": [
         {
@@ -4767,9 +4806,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.313",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
-      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
+      "version": "1.5.321",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
+      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -4968,9 +5007,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7020,9 +7059,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -7071,9 +7110,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.88.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
-      "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8655,9 +8694,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vpx-editor",
   "productName": "VPX Editor",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Visual Pinball X Table Editor",
   "main": ".vite/build/main.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "vite": "^7.3.0"
   },
   "dependencies": {
-    "@francisdb/vpin-wasm": "^0.23.1",
+    "@francisdb/vpin-wasm": "^0.23.5",
     "electron-squirrel-startup": "^1.0.1",
     "fs-extra": "^11.3.3",
     "monaco-editor": "^0.55.1",

--- a/src/editor/parts/flasher.ts
+++ b/src/editor/parts/flasher.ts
@@ -177,6 +177,7 @@ function getStyleOptions(mode: string, selectedStyle: number | undefined): strin
   const styles: Record<string, string[]> = {
     dmd: ['Legacy VPX', 'Neon Plasma', 'Red LED', 'Green LED', 'Yellow LED', 'Generic Plasma', 'Generic LED'],
     display: ['Pixelated', 'Smoothed', 'CRT'],
+    ext_render: ['Backglass', 'Score View', 'Topper'],
     alpha_seg: (() => {
       const families = ['Generic', 'Gottlieb', 'Williams', 'Bally', 'Atari'];
       const types = [
@@ -199,8 +200,12 @@ function getStyleOptions(mode: string, selectedStyle: number | undefined): strin
     })(),
   };
   const opts = styles[mode] || [];
+  const offset = mode === 'ext_render' ? 1 : 0;
   return opts
-    .map((label, i) => `<option value="${i}"${(selectedStyle ?? 0) === i ? ' selected' : ''}>${label}</option>`)
+    .map((label, i) => {
+      const value = i + offset;
+      return `<option value="${value}"${(selectedStyle ?? offset) === value ? ' selected' : ''}>${label}</option>`;
+    })
     .join('');
 }
 
@@ -208,14 +213,17 @@ export function flasherProperties(item: Flasher): string {
   const mode = item.render_mode || 'flasher';
   const isFlasher = mode === 'flasher';
   const isAlphaSeg = mode === 'alpha_seg';
-  const isDisplay = !isFlasher;
+  const isExtRender = mode === 'ext_render';
+  const isDisplay = !isFlasher && !isExtRender;
   const groupTitle = isFlasher
     ? 'Images'
-    : mode === 'dmd'
-      ? 'DMD Style'
-      : mode === 'display'
-        ? 'Display Style'
-        : 'Alpha Seg. Style';
+    : isExtRender
+      ? 'External Renderer'
+      : mode === 'dmd'
+        ? 'DMD Style'
+        : mode === 'display'
+          ? 'Display Style'
+          : 'Alpha Seg. Style';
   const opacityLabel = isFlasher ? 'Opacity' : 'Brightness';
 
   return `
@@ -233,9 +241,10 @@ export function flasherProperties(item: Flasher): string {
             <option value="dmd"${mode === 'dmd' ? ' selected' : ''}>DMD</option>
             <option value="display"${mode === 'display' ? ' selected' : ''}>Display</option>
             <option value="alpha_seg"${mode === 'alpha_seg' ? ' selected' : ''}>Alpha.Seg.</option>
+            <option value="ext_render"${mode === 'ext_render' ? ' selected' : ''}>External Renderer</option>
           </select>
         </div>
-        <div class="prop-row">
+        <div class="prop-row" style="${isExtRender ? 'display:none' : ''}">
           <label class="prop-label">Color</label>
           <input type="color" class="prop-input" data-prop="color" value="${item.color || '#ffffff'}">
         </div>
@@ -250,7 +259,7 @@ export function flasherProperties(item: Flasher): string {
       </div>
       <div class="prop-group">
         <div class="prop-group-title">${groupTitle}</div>
-        <div class="prop-row" style="${isDisplay ? '' : 'display:none'}">
+        <div class="prop-row" style="${isDisplay || isExtRender ? '' : 'display:none'}">
           <label class="prop-label">Render Style</label>
           <select class="prop-select" data-prop="render_style" data-type="int">${getStyleOptions(mode, item.render_style)}</select>
         </div>
@@ -311,7 +320,7 @@ export function flasherProperties(item: Flasher): string {
           <input type="checkbox" class="prop-input" data-prop="display_texture" ${item.display_texture !== false ? 'checked' : ''}>
         </div>
       </div>
-      <div class="prop-group">
+      <div class="prop-group" style="${isExtRender ? 'display:none' : ''}">
         <div class="prop-group-title">Transparency</div>
         <div class="prop-row">
           <label class="prop-label">${opacityLabel}</label>

--- a/src/types/game-objects.ts
+++ b/src/types/game-objects.ts
@@ -565,7 +565,7 @@ export interface Flasher extends GameObject {
   filter_amount: number;
   depth_bias: number;
   render_style: number;
-  render_mode?: 'flasher' | 'dmd' | 'display' | 'alpha_seg' | string;
+  render_mode?: 'flasher' | 'dmd' | 'display' | 'alpha_seg' | 'ext_render' | string;
   image_a?: string;
   image_b?: string;
   image_src_link?: string;


### PR DESCRIPTION
This adds support for the new `EXT_RENDER` mode for flashers in 10.8.1.

We can now set flashers to render the backglass, scoreview, and topper ancillary windows. Thanks @vbousquet for adding this feature.

Thanks, @francisdb for quickly adding support to `vpin-wasm`!