### PR TITLE
misc: remove unused vpxtool settings fields

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -2370,8 +2370,6 @@ ipcMain.handle(
       textureQuality?: number;
       unitConversion?: string;
       vpinballPath?: string;
-      useEmbeddedVpxtool?: boolean;
-      vpxtoolPath?: string;
       alwaysDrawDragPoints?: boolean;
       drawLightCenters?: boolean;
       editorColors?: Record<string, string>;


### PR DESCRIPTION
Removes two never-read fields from the `save-settings` IPC handler payload type in `src/desktop/main.ts`:

- `useEmbeddedVpxtool?: boolean`
- `vpxtoolPath?: string`

Mesh import/export moved to `@francisdb/vpin-wasm` in 030afab, so vpxtool is no longer involved at runtime. A grep of the codebase confirms these two field names are declared but never read.


- [ ] CI typecheck still passes (only thing exercising this type) -> needs rebase on #51 