### PR TITLE
ci: run build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+  pull_request:
 
 defaults:
   run:


### PR DESCRIPTION
Adds `pull_request:` to the build workflow's triggers so PRs from contributors get CI feedback automatically.